### PR TITLE
Update to Hugo 0.140

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -27,7 +27,8 @@ Params:
 
 enableGitInfo: false
 summaryLength: 30
-paginate: 10
+pagination:
+  pagerSize: 10
 enableEmoji: true
 enableRobotsTXT: true
 footnotereturnlinkcontents: <sup>^</sup>

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,13 @@ module github.com/alkem-io/website
 go 1.19
 
 require (
-	github.com/HugoBlox/hugo-blox-builder/modules/blox-bootstrap/v5 v5.9.7-0.20231113222801-e48152bc9311
-	github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-decap-cms v0.1.2-0.20231113222801-e48152bc9311
-	github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-netlify v1.1.2-0.20231113222801-e48152bc9311
+	github.com/HugoBlox/hugo-blox-builder/modules/blox-bootstrap/v5 v5.9.7
+	github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-decap-cms v0.1.2-0.20241223201730-71de892c1c61
+	github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-netlify v1.1.2-0.20241223201730-71de892c1c61
 	github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-reveal v1.1.3-0.20231113222801-e48152bc9311
 )
 
+require (
+	github.com/HugoBlox/hugo-blox-builder/modules/blox-core v0.3.1 // indirect
+	github.com/HugoBlox/hugo-blox-builder/modules/blox-seo v0.2.3 // indirect
+)

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -188,7 +188,7 @@
   {{/* Load WC community block styles */}}
   {{ $wc_block_styles := resources.Match "scss/blocks/**.scss" }}
   {{ with $wc_block_styles }}
-    {{ $wc_block_styles = $wc_block_styles | resources.Concat "css/wowchemy-blocks.scss" | resources.ToCSS }}
+    {{ $wc_block_styles = $wc_block_styles | resources.Concat "css/wowchemy-blocks.scss" | css.Sass }}
     {{- if eq (getenv "WC_POST_CSS") "true" -}}
       {{- $wc_block_styles = $wc_block_styles | postCSS -}}
     {{- end -}}


### PR DESCRIPTION
- Updated hugo locally and fixed the problems with our files
- Updated hugo modules

- If you have problems testing it locally, you may want to try these two:
   - Delete hugo cache: 
       - On Linux is in `~/.cache/hugo_cache/`
       - On Mac is in `/Users/<youruser>/Library/Caches/hugo_cache`
       - On Windows somewhere similar
   - Delete the generated `public` folder in the project root. Specially if it says something about permissions copying a font file. looks like a [Hugo problem](https://discourse.gohugo.io/t/overwriting-static-files/47303)