### PR TITLE
Updating pagination to clean page rendering.

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -28,7 +28,7 @@ Params:
 enableGitInfo: false
 summaryLength: 30
 pagination:
-  pagerSize: 10
+  pagerSize: 9
 enableEmoji: true
 enableRobotsTXT: true
 footnotereturnlinkcontents: <sup>^</sup>


### PR DESCRIPTION
### Describe the background of your pull request

The earlier limit of 10 per page did not interact well with a #mod3, especially the page rendering. The pagination is updated to 9. 

### Additional context

This pull request is connected to issue #813 BUG: Misaligned rendering on blog landing page

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated pagination settings: Pages now display 9 items instead of 10, resulting in a more refined content grouping and improved navigation experience. This change ensures that users benefit from a consistent layout, offering a slightly adjusted list per page that enhances overall browsing experience. Enjoy a streamlined and intuitive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->