### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/bunny-edge-rules.yml
+++ b/.github/workflows/bunny-edge-rules.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Apply edge rules
         run: ./scripts/bunny-edge-rules.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: '1.21'
 
@@ -56,7 +56,7 @@ jobs:
           extended: true
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
Bump GitHub Actions to latest releases (org-wide actions audit, 2026-07-21).

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v6 | v7 |
| `actions/setup-go` | v6 | v7 |
| `actions/setup-node` | v6 | v7 |

Compatibility: all `with:` inputs validated against each action's schema at the target version; bumped actions run on node24 (GitHub-hosted runners OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
