### PR TITLE
docs(dco): CLA→DCO in LICENSES.md; fix dead alkemio org link

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,6 +1,6 @@
 The Stichting Alkemio ("Stichting") reserves all rights to the works that belong to the Sitchting published on this GitHub account. Nevertheless, reuse is permitted under the following conditions.
 
-First - The work that is created in the Alkemio project, is available under the EU-PL license; and any outside contributions to it are under an [individual Contributor License Agreement](https://github.com/alkemio/.github/blob/master/CLA.md) ("CLA") that references this license explicitly.
+First - The work that is created in the Alkemio project, is available under the EU-PL license; and any outside contributions to it from the DCO cut-over date onward are certified under the [Developer Certificate of Origin 1.1](https://developercertificate.org/) ("DCO") through a per-commit `Signed-off-by` trailer. Contributions made before the cut-over were covered by the retired [individual Contributor License Agreement](https://github.com/alkem-io/.github/blob/master/CLA.md) ("CLA"), kept as a historical reference.
 
 However - that does not mean that all (derived) work is solely under that single license. For example - where appropriate certain (open source) modules may be required and included. These will remain under their original Copyright and License (though some may be released under the EU-PL license if they are unsuitable to be contributed back upstream).
 


### PR DESCRIPTION
One-file docs slice of the CLA→DCO migration (`workspace#035-dco-migration`, story `alkem-io/infrastructure-operations#2186`).

Found the same way as the `foundation` PR: the spec-compliance reviewer showed FR-015's *"zero CLA-signing instructions on governed repos"* was false while this repo — in the 39-repo governed set — still carried one.

## Changes — `LICENSES.md`

- The EUPL paragraph now states outside contributions from the cut-over date are certified under [DCO 1.1](https://developercertificate.org/) via a per-commit `Signed-off-by`; contributions made earlier were covered by the CLA, kept as a historical reference. Mirrors the `alkemio/LICENSES.md` wording.
- Fixed the dead `github.com/alkemio/.github` link (correct org is `alkem-io`).

CC0 and image-licensing paragraphs untouched. Docs only, one file.

---

## Evidence

Full run ledger: [`specs/035-dco-migration/forge-run.md`](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/forge-run.md) · [spec](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/spec.md) · [plan](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/plan.md) · [runbook](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/runbook.md) · [ADR 0008](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/docs/decisions/0008-dco-enforcement-contract.md)

**Review**: 4 dimensions (correctness · spec-compliance · quality · security) over **7 security rounds**. Every round found something real; rounds 4–7 found defects in the *previous round's remediation*. Two criticals were confirmed by adversarial reproduction against live payloads.

**All commits GPG-signed and DCO signed-off** — this feature's own policy applied to itself.

### Residuals the reviewer ruled trackable (not blockers)

| # | Residual | Severity |
|---|---|---|
| S7-1 | A local actor with evidence-write access can forge a rollback bundle **legally indistinguishable** from a genuine one. Not patchable by comparison — a discriminating guard was built, found to break legitimate recovery, and reverted. Interim control: the H4/H6 human gates. | high |
| D1 | remove-CLA evidence not artifact-bound beyond journals + live pinned-DCO verification | medium |
| D6 | Installer lacks a signed-revision provenance anchor | medium |
| D7 | H5 sweep omits immutable check-run id/URL fields | low |

⚠️ **The round-7 remediation is unreviewed** — it landed after the last review's pinned SHAs.

**This PR changes no live GitHub setting.** All enforcement happens at human gates H1a–H8 per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
